### PR TITLE
Add additional check for member to get round odd silverstripe behaviour

### DIFF
--- a/code/Testimonial.php
+++ b/code/Testimonial.php
@@ -88,14 +88,20 @@ class Testimonial extends DataObject{
 	}
 
 	public function canCreate($member = null) {
+        if(!$member) $member = Member::currentUser();
+        
 		return (boolean)$member;
 	}
 
 	public function canEdit($member = null) {
+        if(!$member) $member = Member::currentUser();
+        
 		return Permission::check("CMS_ACCESS_CMSMain") || ($member && $this->MemberID == $member->ID);
 	}
 
 	public function canDelete($member = null) {
+        if(!$member) $member = Member::currentUser();
+        
 		return Permission::check("CMS_ACCESS_CMSMain") || ($member && $this->MemberID == $member->ID);
 	}
 


### PR DESCRIPTION
Silverstripe seems to behave very oddly with gridfield and the "can" permissions. Member doesn't always seem to be sent from gridfield to the object, so I have added manual calls if it is not.